### PR TITLE
[interface-segregation] Create before and after implementation ISP

### DIFF
--- a/SOLID Principles.xcodeproj/project.pbxproj
+++ b/SOLID Principles.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7675B993298A4E51007AF3A7 /* ContentView.swift */; };
 		7675B996298A4E51007AF3A7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B995298A4E51007AF3A7 /* Assets.xcassets */; };
 		7675B999298A4E51007AF3A7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */; };
+		76F4511329953DA600BB1C0C /* ISP_Before.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F4511229953DA600BB1C0C /* ISP_Before.swift */; };
+		76F4511529953DB900BB1C0C /* ISP_After.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F4511429953DB900BB1C0C /* ISP_After.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +21,8 @@
 		7675B993298A4E51007AF3A7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7675B995298A4E51007AF3A7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		76F4511229953DA600BB1C0C /* ISP_Before.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISP_Before.swift; sourceTree = "<group>"; };
+		76F4511429953DB900BB1C0C /* ISP_After.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISP_After.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +55,7 @@
 		7675B990298A4E51007AF3A7 /* SOLID Principles */ = {
 			isa = PBXGroup;
 			children = (
+				76F4511129953D9100BB1C0C /* Interface Segregation */,
 				7675B991298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift */,
 				7675B993298A4E51007AF3A7 /* ContentView.swift */,
 				7675B995298A4E51007AF3A7 /* Assets.xcassets */,
@@ -65,6 +70,15 @@
 				7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		76F4511129953D9100BB1C0C /* Interface Segregation */ = {
+			isa = PBXGroup;
+			children = (
+				76F4511229953DA600BB1C0C /* ISP_Before.swift */,
+				76F4511429953DB900BB1C0C /* ISP_After.swift */,
+			);
+			path = "Interface Segregation";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -139,6 +153,8 @@
 			files = (
 				7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */,
 				7675B992298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift in Sources */,
+				76F4511329953DA600BB1C0C /* ISP_Before.swift in Sources */,
+				76F4511529953DB900BB1C0C /* ISP_After.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SOLID Principles/Interface Segregation/ISP_After.swift
+++ b/SOLID Principles/Interface Segregation/ISP_After.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+protocol FuelType {
+    func fuel()
+}
+
+protocol Speed{
+    func speed()
+}
+
+class CarAfter: FuelType, Speed {
+    var topSpeed: Int = 180
+    var fuelType: String = "gas"
+
+    func speed() {
+        print("the speed is \(topSpeed)")
+    }
+
+    func fuel() {
+        print("the fuel is gas")
+    }
+}
+
+class BikeAfter: Speed {
+    func speed() {
+        fatalError("fuel does not exist")
+    }
+}

--- a/SOLID Principles/Interface Segregation/ISP_Before.swift
+++ b/SOLID Principles/Interface Segregation/ISP_Before.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+//In summary, Clients should not be forced to depend upon interfaces that they do not use.
+//No code should be forced to depend on methods it does not use.
+
+protocol Transportation {
+    func speed()
+    func fuel()
+}
+
+class Car: Transportation {
+    var topSpeed: Int = 180
+    var fuelType: String = "gas"
+    
+    func speed() {
+        print("the speed is \(topSpeed)")
+    }
+
+    func fuel() {
+        print("the fuel is gas")
+    }
+}
+
+class Bike: Transportation {
+    var topSpeed: Int = 18
+
+    func speed() {
+        print("the speed is \(topSpeed)")
+    }
+    
+    func fuel() {
+        fatalError("fuel does not exist")
+    }
+}
+
+//The problem starts here because Transportation protocol has two functions, one is speed and one is fuel, there is no problem for the speed function, the fuel function causes an unnecessary responsibility to be passed to the class. This is an ISP break.


### PR DESCRIPTION
The interface segregation principle indicates that it is better to have different interfaces (protocols) that are specific to each client than to have a general interface.