### PR TITLE
[dependency-inversion] Create before and after implementation DIP

### DIFF
--- a/SOLID Principles.xcodeproj/project.pbxproj
+++ b/SOLID Principles.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7675B993298A4E51007AF3A7 /* ContentView.swift */; };
 		7675B996298A4E51007AF3A7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B995298A4E51007AF3A7 /* Assets.xcassets */; };
 		7675B999298A4E51007AF3A7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */; };
+		76F4511A2995457500BB1C0C /* DIP_After.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F451192995457500BB1C0C /* DIP_After.swift */; };
+		76F4511C2995458800BB1C0C /* DIP_Before.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F4511B2995458800BB1C0C /* DIP_Before.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +21,8 @@
 		7675B993298A4E51007AF3A7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7675B995298A4E51007AF3A7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		76F451192995457500BB1C0C /* DIP_After.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIP_After.swift; sourceTree = "<group>"; };
+		76F4511B2995458800BB1C0C /* DIP_Before.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIP_Before.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +55,7 @@
 		7675B990298A4E51007AF3A7 /* SOLID Principles */ = {
 			isa = PBXGroup;
 			children = (
+				76F451182995454800BB1C0C /* DependencyInversion */,
 				7675B991298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift */,
 				7675B993298A4E51007AF3A7 /* ContentView.swift */,
 				7675B995298A4E51007AF3A7 /* Assets.xcassets */,
@@ -65,6 +70,15 @@
 				7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		76F451182995454800BB1C0C /* DependencyInversion */ = {
+			isa = PBXGroup;
+			children = (
+				76F451192995457500BB1C0C /* DIP_After.swift */,
+				76F4511B2995458800BB1C0C /* DIP_Before.swift */,
+			);
+			path = DependencyInversion;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,7 +151,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				76F4511A2995457500BB1C0C /* DIP_After.swift in Sources */,
 				7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */,
+				76F4511C2995458800BB1C0C /* DIP_Before.swift in Sources */,
 				7675B992298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SOLID Principles/DependencyInversion/DIP_After.swift
+++ b/SOLID Principles/DependencyInversion/DIP_After.swift
@@ -1,0 +1,22 @@
+import Foundation
+import UIKit
+
+protocol Storable { }
+protocol StorageManager {
+
+  func save(object: Storable)
+}
+
+class CarAfter: Storable {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+}
+
+class ServiceAfter: StorageManager {
+    func save(object: Storable) {
+        // Saves user to database
+    }
+}

--- a/SOLID Principles/DependencyInversion/DIP_Before.swift
+++ b/SOLID Principles/DependencyInversion/DIP_Before.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+//This principle tries to reduce the dependencies between modules, and thus achieve a lower coupling between classes.
+
+class Car {
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+}
+
+class SaveData {
+    func save(car: Car) {
+        // Save car on database
+    }
+}
+
+class Service {
+    func save(car: Car) {
+        let save = SaveData()
+        save.save(car: car)
+    }
+}

--- a/SOLID Principles/SOLID_PrinciplesApp.swift
+++ b/SOLID Principles/SOLID_PrinciplesApp.swift
@@ -1,10 +1,3 @@
-//
-//  SOLID_PrinciplesApp.swift
-//  SOLID Principles
-//
-//  Created by Camelia Braghes on 01.02.2023.
-//
-
 import SwiftUI
 
 @main


### PR DESCRIPTION
According to the dependency inversion principle:

- High-level classes should not depend on low-level classes.Both should depend on abstractions.
- Abstractions should not depend on the details. The details should depend on the abstractions.