### PR TITLE
[liskov-substitution] Create before and after implementation LSP

### DIFF
--- a/SOLID Principles.xcodeproj/project.pbxproj
+++ b/SOLID Principles.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7675B993298A4E51007AF3A7 /* ContentView.swift */; };
 		7675B996298A4E51007AF3A7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B995298A4E51007AF3A7 /* Assets.xcassets */; };
 		7675B999298A4E51007AF3A7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */; };
+		76F4510E29952D6000BB1C0C /* LSP_After.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F4510D29952D6000BB1C0C /* LSP_After.swift */; };
+		76F4511029952D7600BB1C0C /* LSP_Before.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F4510F29952D7600BB1C0C /* LSP_Before.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +21,8 @@
 		7675B993298A4E51007AF3A7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7675B995298A4E51007AF3A7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		76F4510D29952D6000BB1C0C /* LSP_After.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSP_After.swift; sourceTree = "<group>"; };
+		76F4510F29952D7600BB1C0C /* LSP_Before.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSP_Before.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,6 +55,7 @@
 		7675B990298A4E51007AF3A7 /* SOLID Principles */ = {
 			isa = PBXGroup;
 			children = (
+				76F4510C29952D3600BB1C0C /* Liskov Substitution */,
 				7675B991298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift */,
 				7675B993298A4E51007AF3A7 /* ContentView.swift */,
 				7675B995298A4E51007AF3A7 /* Assets.xcassets */,
@@ -65,6 +70,15 @@
 				7675B998298A4E51007AF3A7 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		76F4510C29952D3600BB1C0C /* Liskov Substitution */ = {
+			isa = PBXGroup;
+			children = (
+				76F4510D29952D6000BB1C0C /* LSP_After.swift */,
+				76F4510F29952D7600BB1C0C /* LSP_Before.swift */,
+			);
+			path = "Liskov Substitution";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,8 +151,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				76F4511029952D7600BB1C0C /* LSP_Before.swift in Sources */,
 				7675B994298A4E51007AF3A7 /* ContentView.swift in Sources */,
 				7675B992298A4E51007AF3A7 /* SOLID_PrinciplesApp.swift in Sources */,
+				76F4510E29952D6000BB1C0C /* LSP_After.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SOLID Principles/Liskov Substitution/LSP_After.swift
+++ b/SOLID Principles/Liskov Substitution/LSP_After.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+class CarServiceAfter {
+    func contact(costumer: Costumer) {
+        guard costumer.isRepairCar else { return }
+        self.contact(costumer: Costumer(name: costumer.name, phone: costumer.phone, isRepairCar: costumer.isRepairCar))
+    }
+}

--- a/SOLID Principles/Liskov Substitution/LSP_Before.swift
+++ b/SOLID Principles/Liskov Substitution/LSP_Before.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+
+//A subclass should be able to override the parent class method in a way that doesn’t break
+//the functionality of the base class.The benefit of this principle is that when code is interchangeable, it becomes more reusable.
+
+struct Costumer {
+    var name: String = "ion"
+    var phone: String = "07..."
+    var isRepairCar: Bool = true
+}
+
+class CarService {
+    func contact(costumer: Costumer) {
+        // contact the costumer
+    }
+}
+
+class ValidRepareCar {
+    func  contact(costumer: Costumer) {
+        guard costumer.isRepairCar else { return }
+        self.contact(costumer: Costumer(name: costumer.name, phone: costumer.phone, isRepairCar: costumer.isRepairCar))
+    }
+}
+
+// In this case, the Liskov substitution principle is not fulfilled, since the subclass adds a condition(isRepairCar).
+// We can solve this problem by not creating the subclass, and adding the precondition to CarService (including a default value)

--- a/SOLID Principles/SOLID_PrinciplesApp.swift
+++ b/SOLID Principles/SOLID_PrinciplesApp.swift
@@ -1,10 +1,3 @@
-//
-//  SOLID_PrinciplesApp.swift
-//  SOLID Principles
-//
-//  Created by Camelia Braghes on 01.02.2023.
-//
-
 import SwiftUI
 
 @main


### PR DESCRIPTION
A subclass should be able to override the parent class method in a way that doesn’t break the functionality of the base class. The benefit of this principle is that when code is interchangeable, it becomes more reusable.